### PR TITLE
Change reg expression

### DIFF
--- a/lib/linkify.dart
+++ b/lib/linkify.dart
@@ -24,7 +24,7 @@ class TextElement extends LinkifyElement {
   }
 }
 
-final _linkifyRegex = RegExp(r"(.*?\s*?)((?:https?):\/\/[^\s/$.?#].[^\s]*)",
+final _linkifyRegex = RegExp(r"/(?:(?:https?|ftp|file):\/\/|www\.|ftp\.)(?:\([-A-Z0-9+&@#\/%=~_|$?!:,.]*\)|[-A-Z0-9+&@#\/%=~_|$?!:,.])*(?:\([-A-Z0-9+&@#\/%=~_|$?!:,.]*\)|[A-Z0-9+&@#\/%=~_|$])/igm",
     caseSensitive: false);
 
 /// Turns [text] into a list of [LinkifyElement]


### PR DESCRIPTION
Change reg expression to allow other links like `www.google.com` without the need to start with http

CreditI goes for https://stackoverflow.com/a/29288898/1908005 

- It does not match email addresses
- It does match localhost:12345
- It won't detect something like moo.com without http or www

It should fix https://github.com/Cretezy/flutter_linkify/issues/2