### PR TITLE
Add textScaleFactor to Linkify Widget

### DIFF
--- a/lib/flutter_linkify.dart
+++ b/lib/flutter_linkify.dart
@@ -49,6 +49,9 @@ class Linkify extends StatelessWidget {
   final int maxLines;
   final TextOverflow overflow;
 
+  /// Text scale factor
+  final double textScaleFactor;
+
   const Linkify({
     Key key,
     this.text,
@@ -63,6 +66,7 @@ class Linkify extends StatelessWidget {
     this.textDirection,
     this.maxLines,
     this.overflow = TextOverflow.ellipsis,
+    this.textScaleFactor,
   }) : super(key: key);
 
   @override
@@ -78,6 +82,8 @@ class Linkify extends StatelessWidget {
       textDirection: textDirection,
       maxLines: maxLines,
       overflow: overflow,
+      textScaleFactor:
+          textScaleFactor ?? MediaQuery.of(context).textScaleFactor,
       text: buildTextSpan(
         elements,
         style: Theme.of(context).textTheme.body1.merge(style),


### PR DESCRIPTION
RichText, as opposed to Text, does not read the textScaleFactor from MediaQuery automatically.

This PR fixes that issue.

textScaleFactor is an important parameter to preserve
accessibility in text Widgets, since we need to scale
the font size depending on what the user has configured
in their operating system.

If the developer does not provide any value, the system
scale factor will be used.

If the developer provides a specific value, it will override
the defaults.

I use this solution in my project to support accessibility font scaling with Linkify, and it would be great if everyone could have it by default for free! :)
