### PR TITLE
RichText --> Text.rich

### DIFF
--- a/lib/flutter_linkify.dart
+++ b/lib/flutter_linkify.dart
@@ -98,17 +98,8 @@ class Linkify extends StatelessWidget {
       linkifiers: linkifiers,
     );
 
-    return RichText(
-      textAlign: textAlign,
-      textDirection: textDirection,
-      maxLines: maxLines,
-      overflow: overflow,
-      textScaleFactor: textScaleFactor,
-      softWrap: softWrap,
-      strutStyle: strutStyle,
-      locale: locale,
-      textWidthBasis: textWidthBasis,
-      text: buildTextSpan(
+    return Text.rich(
+      buildTextSpan(
         elements,
         style: Theme.of(context).textTheme.bodyText2.merge(style),
         onOpen: onOpen,
@@ -122,6 +113,15 @@ class Linkify extends StatelessWidget {
             )
             .merge(linkStyle),
       ),
+      textAlign: textAlign,
+      textDirection: textDirection,
+      maxLines: maxLines,
+      overflow: overflow,
+      textScaleFactor: textScaleFactor,
+      softWrap: softWrap,
+      strutStyle: strutStyle,
+      locale: locale,
+      textWidthBasis: textWidthBasis,
     );
   }
 }


### PR DESCRIPTION
`RichText` introduces several problems, e.g. font scaling not working properly. People are meant to use `Text.rich` instead, where `RichText` is more meant to be a flutter-internal widget. See https://github.com/flutter/flutter/issues/14675

As such, `RichText` might be renamed to `RawText` in the future anyways, to discourage its use https://github.com/flutter/flutter/issues/24722

This PR replaces `RichText` with `Text.rich`