### PR TITLE
let useMouseRegion be settable

### DIFF
--- a/lib/flutter_linkify.dart
+++ b/lib/flutter_linkify.dart
@@ -73,6 +73,8 @@ class Linkify extends StatelessWidget {
   /// Defines how the paragraph will apply TextStyle.height to the ascent of the first line and descent of the last line.
   final TextHeightBehavior? textHeightBehavior;
 
+  final bool useMouseRegion;
+
   const Linkify({
     Key? key,
     required this.text,
@@ -93,6 +95,7 @@ class Linkify extends StatelessWidget {
     this.locale,
     this.textWidthBasis = TextWidthBasis.parent,
     this.textHeightBehavior,
+    this.useMouseRegion = false
   }) : super(key: key);
 
   @override
@@ -108,7 +111,7 @@ class Linkify extends StatelessWidget {
         elements,
         style: Theme.of(context).textTheme.bodyText2?.merge(style),
         onOpen: onOpen,
-        useMouseRegion: true,
+        useMouseRegion: useMouseRegion,
         linkStyle: Theme.of(context)
             .textTheme
             .bodyText2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_linkify
 description: Turns text URLs and emails into clickable inline links in text for Flutter.
-version: 5.0.2
+version: 5.0.3
 homepage: https://github.com/Cretezy/flutter_linkify
 
 environment:


### PR DESCRIPTION
Due to useMouseRegion be force true, link style will draw underline automatically and can't be remove by other settings. 