### PR TITLE
Add prefixText and prefixTextStyle

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,24 +16,45 @@ class LinkifyExample extends StatelessWidget {
         appBar: AppBar(
           title: Text('flutter_linkify example'),
         ),
-        body: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: <Widget>[
-            Center(
-              child: Linkify(
-                onOpen: _onOpen,
-                textScaleFactor: 2,
-                text: "Made by https://cretezy.com\n\nMail: example@gmail.com",
+        body: SingleChildScrollView
+        (
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: <Widget>[
+              Center(
+                child: Linkify(
+                  onOpen: _onOpen,
+                  textScaleFactor: 2,
+                  text: "Made by https://cretezy.com\n\nMail: example@gmail.com",
+                ),
               ),
-            ),
-            Center(
-              child: SelectableLinkify(
-                onOpen: _onOpen,
-                textScaleFactor: 4,
-                text: "Made by https://cretezy.com\n\nMail: example@gmail.com",
+              Center(
+                child: Linkify(
+                  onOpen: _onOpen,
+                  textScaleFactor: 2,
+                  text: "Made by https://cretezy.com\n\nMail: example@gmail.com",
+                  prefixText: "Prefix Text: ",
+                  prefixTextStyle: TextStyle(color: Colors.green),
+                ),
               ),
-            ),
-          ],
+              Center(
+                child: SelectableLinkify(
+                  onOpen: _onOpen,
+                  textScaleFactor: 4,
+                  text: "Made by https://cretezy.com\n\nMail: example@gmail.com",
+                ),
+              ),
+              Center(
+                child: SelectableLinkify(
+                  onOpen: _onOpen,
+                  textScaleFactor: 4,
+                  text: "Made by https://cretezy.com\n\nMail: example@gmail.com",
+                  prefixText: "Prefix Text: ",
+                  prefixTextStyle: TextStyle(color: Colors.green),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/flutter_linkify.dart
+++ b/lib/flutter_linkify.dart
@@ -40,6 +40,12 @@ class Linkify extends StatelessWidget {
   /// Style of link text
   final TextStyle? linkStyle;
 
+  /// Text to be displayed before the main [text]
+  final String? prefixText;
+
+  /// Style for [prefixText]
+  final TextStyle? prefixTextStyle;
+
   // Text.rich
 
   /// How the text should be aligned horizontally.
@@ -82,6 +88,8 @@ class Linkify extends StatelessWidget {
     // TextSpan
     this.style,
     this.linkStyle,
+    this.prefixText,
+    this.prefixTextStyle,
     // RichText
     this.textAlign = TextAlign.start,
     this.textDirection,
@@ -118,6 +126,8 @@ class Linkify extends StatelessWidget {
               decoration: TextDecoration.underline,
             )
             .merge(linkStyle),
+        prefixText: prefixText,
+        prefixTextStyle: prefixTextStyle,
       ),
       textAlign: textAlign,
       textDirection: textDirection,
@@ -157,6 +167,12 @@ class SelectableLinkify extends StatelessWidget {
 
   /// Style of link text
   final TextStyle? linkStyle;
+
+  /// Text to be displayed before the main [text]
+  final String? prefixText;
+
+  /// Style for [prefixText]
+  final TextStyle? prefixTextStyle;
 
   // Text.rich
 
@@ -234,6 +250,8 @@ class SelectableLinkify extends StatelessWidget {
     // TextSpan
     this.style,
     this.linkStyle,
+    this.prefixText,
+    this.prefixTextStyle,
     // RichText
     this.textAlign,
     this.textDirection,
@@ -282,6 +300,8 @@ class SelectableLinkify extends StatelessWidget {
               decoration: TextDecoration.underline,
             )
             .merge(linkStyle),
+        prefixText: prefixText,
+        prefixTextStyle: prefixTextStyle,
       ),
       textAlign: textAlign,
       textDirection: textDirection,
@@ -330,8 +350,12 @@ TextSpan buildTextSpan(
   TextStyle? linkStyle,
   LinkCallback? onOpen,
   bool useMouseRegion = false,
+  String? prefixText,
+  TextStyle? prefixTextStyle,
 }) {
   return TextSpan(
+    text: prefixText,
+    style: prefixTextStyle,
     children: elements.map<InlineSpan>(
       (element) {
         if (element is LinkableElement) {


### PR DESCRIPTION
Currently we can't add a styled text before the main linkify text, this PR adds that feature 



Screenshots from updated example:
<img width="1356" alt="Screen Shot 2021-07-19 at 19 23 20" src="https://user-images.githubusercontent.com/37366956/126208370-b98129aa-3b06-4bbd-9bc6-239052434318.png">

<img width="612" alt="Screen Shot 2021-07-19 at 19 25 36" src="https://user-images.githubusercontent.com/37366956/126208696-008aa181-36e5-4710-a77c-628a9acf0e26.png">