### PR TITLE
Use bodyText2 only if there's no style passed in parameters

### DIFF
--- a/lib/flutter_linkify.dart
+++ b/lib/flutter_linkify.dart
@@ -73,6 +73,8 @@ class Linkify extends StatelessWidget {
   /// Defines how the paragraph will apply TextStyle.height to the ascent of the first line and descent of the last line.
   final TextHeightBehavior? textHeightBehavior;
 
+  final bool useMouseRegion;
+
   const Linkify({
     Key? key,
     required this.text,
@@ -93,6 +95,7 @@ class Linkify extends StatelessWidget {
     this.locale,
     this.textWidthBasis = TextWidthBasis.parent,
     this.textHeightBehavior,
+    this.useMouseRegion = true,
   }) : super(key: key);
 
   @override
@@ -106,18 +109,16 @@ class Linkify extends StatelessWidget {
     return Text.rich(
       buildTextSpan(
         elements,
-        style: Theme.of(context).textTheme.bodyText2?.merge(style),
+        style: style ?? Theme.of(context).textTheme.bodyText2,
         onOpen: onOpen,
-        useMouseRegion: true,
-        linkStyle: Theme.of(context)
-            .textTheme
-            .bodyText2
-            ?.merge(style)
-            .copyWith(
-              color: Colors.blueAccent,
-              decoration: TextDecoration.underline,
-            )
-            .merge(linkStyle),
+        useMouseRegion: useMouseRegion,
+        linkStyle: style
+                ?.copyWith(
+                  color: Colors.blueAccent,
+                  decoration: TextDecoration.underline,
+                )
+                .merge(linkStyle) ??
+            Theme.of(context).textTheme.bodyText2,
       ),
       textAlign: textAlign,
       textDirection: textDirection,
@@ -225,6 +226,8 @@ class SelectableLinkify extends StatelessWidget {
   /// Called when the user changes the selection of text (including the cursor location).
   final SelectionChangedCallback? onSelectionChanged;
 
+  final bool useMouseRegion;
+
   const SelectableLinkify({
     Key? key,
     required this.text,
@@ -258,6 +261,7 @@ class SelectableLinkify extends StatelessWidget {
     this.cursorHeight,
     this.selectionControls,
     this.onSelectionChanged,
+    this.useMouseRegion = false,
   }) : super(key: key);
 
   @override
@@ -271,17 +275,16 @@ class SelectableLinkify extends StatelessWidget {
     return SelectableText.rich(
       buildTextSpan(
         elements,
-        style: Theme.of(context).textTheme.bodyText2?.merge(style),
+        style: style ?? Theme.of(context).textTheme.bodyText2,
         onOpen: onOpen,
-        linkStyle: Theme.of(context)
-            .textTheme
-            .bodyText2
-            ?.merge(style)
-            .copyWith(
-              color: Colors.blueAccent,
-              decoration: TextDecoration.underline,
-            )
-            .merge(linkStyle),
+        linkStyle: style
+                ?.copyWith(
+                  color: Colors.blueAccent,
+                  decoration: TextDecoration.underline,
+                )
+                .merge(linkStyle) ??
+            Theme.of(context).textTheme.bodyText2,
+        useMouseRegion: useMouseRegion,
       ),
       textAlign: textAlign,
       textDirection: textDirection,
@@ -341,14 +344,18 @@ TextSpan buildTextSpan(
               inlineSpan: TextSpan(
                 text: element.text,
                 style: linkStyle,
-                recognizer: onOpen != null ? (TapGestureRecognizer()..onTap = () => onOpen(element)) : null,
+                recognizer: onOpen != null
+                    ? (TapGestureRecognizer()..onTap = () => onOpen(element))
+                    : null,
               ),
             );
           } else {
             return TextSpan(
               text: element.text,
               style: linkStyle,
-              recognizer: onOpen != null ? (TapGestureRecognizer()..onTap = () => onOpen(element)) : null,
+              recognizer: onOpen != null
+                  ? (TapGestureRecognizer()..onTap = () => onOpen(element))
+                  : null,
             );
           }
         } else {

--- a/lib/flutter_linkify.dart
+++ b/lib/flutter_linkify.dart
@@ -112,13 +112,12 @@ class Linkify extends StatelessWidget {
         style: style ?? Theme.of(context).textTheme.bodyText2,
         onOpen: onOpen,
         useMouseRegion: useMouseRegion,
-        linkStyle: style
-                ?.copyWith(
-                  color: Colors.blueAccent,
-                  decoration: TextDecoration.underline,
-                )
-                .merge(linkStyle) ??
-            Theme.of(context).textTheme.bodyText2,
+        linkStyle: (style ?? Theme.of(context).textTheme.bodyText2)
+            ?.copyWith(
+              color: Colors.blueAccent,
+              decoration: TextDecoration.underline,
+            )
+            .merge(linkStyle),
       ),
       textAlign: textAlign,
       textDirection: textDirection,
@@ -277,13 +276,12 @@ class SelectableLinkify extends StatelessWidget {
         elements,
         style: style ?? Theme.of(context).textTheme.bodyText2,
         onOpen: onOpen,
-        linkStyle: style
-                ?.copyWith(
-                  color: Colors.blueAccent,
-                  decoration: TextDecoration.underline,
-                )
-                .merge(linkStyle) ??
-            Theme.of(context).textTheme.bodyText2,
+        linkStyle: (style ?? Theme.of(context).textTheme.bodyText2)
+            ?.copyWith(
+              color: Colors.blueAccent,
+              decoration: TextDecoration.underline,
+            )
+            .merge(linkStyle),
         useMouseRegion: useMouseRegion,
       ),
       textAlign: textAlign,


### PR DESCRIPTION
Use of `bodyText2` as a base style every time had led to some inconsistencies in text rendering in our case. I made `bodyText2` usage conditional - only when there's no style passed. 

Furthermore, I've added more granular control over `MouseRegion` usage as it may be not necessary in some cases and added more problems to text rendering when using `Text.rich()`.