### PR TITLE
Add LinkifySpan

### DIFF
--- a/lib/flutter_linkify.dart
+++ b/lib/flutter_linkify.dart
@@ -330,37 +330,40 @@ TextSpan buildTextSpan(
   TextStyle? linkStyle,
   LinkCallback? onOpen,
   bool useMouseRegion = false,
-}) {
-  return TextSpan(
-    children: elements.map<InlineSpan>(
-      (element) {
-        if (element is LinkableElement) {
-          if (useMouseRegion) {
-            return LinkableSpan(
-              mouseCursor: SystemMouseCursors.click,
-              inlineSpan: TextSpan(
-                text: element.text,
-                style: linkStyle,
-                recognizer: onOpen != null ? (TapGestureRecognizer()..onTap = () => onOpen(element)) : null,
-              ),
-            );
-          } else {
-            return TextSpan(
-              text: element.text,
-              style: linkStyle,
-              recognizer: onOpen != null ? (TapGestureRecognizer()..onTap = () => onOpen(element)) : null,
-            );
-          }
-        } else {
-          return TextSpan(
+}) =>
+    TextSpan(
+      children: buildTextSpanChildren(
+        elements,
+        style: style,
+        linkStyle: linkStyle,
+        onOpen: onOpen,
+        useMouseRegion: useMouseRegion,
+      ),
+    );
+
+/// Raw TextSpan builder for more control on the RichText
+List<InlineSpan>? buildTextSpanChildren(
+  List<LinkifyElement> elements, {
+  TextStyle? style,
+  TextStyle? linkStyle,
+  LinkCallback? onOpen,
+  bool useMouseRegion = false,
+}) =>
+    [
+      for (var element in elements)
+        if (element is LinkableElement)
+          TextSpan(
+            text: element.text,
+            style: linkStyle,
+            recognizer: onOpen != null ? (TapGestureRecognizer()..onTap = () => onOpen(element)) : null,
+            mouseCursor: useMouseRegion ? SystemMouseCursors.click : null,
+          )
+        else
+          TextSpan(
             text: element.text,
             style: style,
-          );
-        }
-      },
-    ).toList(),
-  );
-}
+          ),
+    ];
 
 class LinkifySpan extends TextSpan {
   LinkifySpan({
@@ -378,13 +381,13 @@ class LinkifySpan extends TextSpan {
     super.semanticsLabel,
     super.locale,
     super.spellOut,
-  }) : super(children: [
-          buildTextSpan(
+  }) : super(
+          children: buildTextSpanChildren(
             linkify(text, options: options, linkifiers: linkifiers),
             style: style,
             linkStyle: linkStyle,
             onOpen: onOpen,
             useMouseRegion: useMouseRegion,
           ),
-        ]);
+        );
 }

--- a/lib/flutter_linkify.dart
+++ b/lib/flutter_linkify.dart
@@ -361,3 +361,30 @@ TextSpan buildTextSpan(
     ).toList(),
   );
 }
+
+class LinkifySpan extends TextSpan {
+  LinkifySpan({
+    required String text,
+    TextStyle? linkStyle,
+    LinkCallback? onOpen,
+    LinkifyOptions options = const LinkifyOptions(),
+    List<Linkifier> linkifiers = defaultLinkifiers,
+    bool useMouseRegion = false,
+    super.style,
+    super.recognizer,
+    super.mouseCursor,
+    super.onEnter,
+    super.onExit,
+    super.semanticsLabel,
+    super.locale,
+    super.spellOut,
+  }) : super(children: [
+          buildTextSpan(
+            linkify(text, options: options, linkifiers: linkifiers),
+            style: style,
+            linkStyle: linkStyle,
+            onOpen: onOpen,
+            useMouseRegion: useMouseRegion,
+          ),
+        ]);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 5.0.2
 homepage: https://github.com/Cretezy/flutter_linkify
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
   flutter: ">=1.13.8"
 
 dependencies:


### PR DESCRIPTION
Add a simple extension of `TextSpan` that directly uses `buildTextSpan`.
`LinkifySpan` is an `InlineSpan` which means that users have more flexibility when using Linkify inside existing `TextSpan` constructs.

Bump min dart version to `2.17.0` to use [super parameters](https://github.com/dart-lang/language/blob/master/working/1855%20-%20super%20parameters/proposal.md).