### PR TITLE
Accessibility: Fix font sizing

### DIFF
--- a/lib/flutter_linkify.dart
+++ b/lib/flutter_linkify.dart
@@ -54,7 +54,7 @@ class Linkify extends StatelessWidget {
   final TextOverflow? overflow;
 
   /// The number of font pixels for each logical pixel
-  final double textScaleFactor;
+  final double? textScaleFactor;
 
   /// Whether the text should break at soft line breaks.
   final bool softWrap;
@@ -88,7 +88,7 @@ class Linkify extends StatelessWidget {
     this.textDirection,
     this.maxLines,
     this.overflow = TextOverflow.clip,
-    this.textScaleFactor = 1.0,
+    this.textScaleFactor = null,
     this.softWrap = true,
     this.strutStyle,
     this.locale,
@@ -138,7 +138,7 @@ class SelectableLinkify extends StatelessWidget {
   final String text;
 
   /// The number of font pixels for each logical pixel
-  final double textScaleFactor;
+  final double? textScaleFactor;
 
   /// Linkifiers to be used for linkify
   final List<Linkifier> linkifiers;
@@ -242,7 +242,7 @@ class SelectableLinkify extends StatelessWidget {
     this.maxLines,
     // SelectableText
     this.focusNode,
-    this.textScaleFactor = 1.0,
+    this.textScaleFactor = null,
     this.strutStyle,
     this.showCursor = false,
     this.autofocus = false,


### PR DESCRIPTION
This plugin would hardcode the font scaling to 1.0 and this would break the font size for anyone using accessibility settings to use a custom font size/scaling. This PR removes this hardcoding.

Before
![image](https://github.com/Cretezy/flutter_linkify/assets/24363938/fd5a5873-5643-4733-b650-25dd9eadd097)

After
![image](https://github.com/Cretezy/flutter_linkify/assets/24363938/08e4b79a-8c4a-4c5e-a451-942be5cc00e7)

Fixes https://github.com/Cretezy/flutter_linkify/issues/22
Fixes https://github.com/Cretezy/flutter_linkify/issues/135
Fixes https://github.com/krille-chan/fluffychat/issues/537
Fixes https://github.com/krille-chan/fluffychat/issues/488